### PR TITLE
fix: Fix UNIX time inconsistency

### DIFF
--- a/client/src/app/components/TransactionObject.tsx
+++ b/client/src/app/components/TransactionObject.tsx
@@ -69,7 +69,7 @@ class TransactionObject extends Component<TransactionObjectProps, TransactionObj
 
         const iac = transactionObject.tag.replace(/\9+$/, "");
 
-        const timeMoment = moment(transactionObject.timestamp * 1000);
+        const timeMoment = (transactionObject.timestamp).toString().length === 10 ? moment(transactionObject.timestamp * 1000) : moment(transactionObject.timestamp) ;
         const attachmentTimeMoment = moment(transactionObject.attachmentTimestamp);
 
         const postDate = (transactionObject.timestamp * 1000) > Date.now() ? "in the future" : "ago";


### PR DESCRIPTION
Some transaction timestamps will be store in the millisecond, so if you still use timestamp * 1000, the time will go wrong.

Example: https://utils.iota.org/transaction/BEQWRLMGEOLZNGPBMBYHBDKTOYABAPGJ99TMTLN9UMHIGPHFPSXCHA9GAGUJGPCNCZWHZJACEUDUZ9999